### PR TITLE
Puppet sync for katello-disconnected

### DIFF
--- a/utils/bin/katello-disconnected
+++ b/utils/bin/katello-disconnected
@@ -286,10 +286,10 @@ subcommands = {
     opts.on( '-e', '--onlyexport', _('Do not create directory structure and only export') ) do
       options[:onlyexport] = true
     end
-    opts.on( '-t', '--start_date START_DATE', _('start date for content export; format: "2009-03-30 00:00:00"') ) do |value|
+    opts.on( '-s', '--start_date START_DATE', _('start date for content export; format: "2009-03-30 00:00:00"') ) do |value|
       options[:start_date] = value
     end
-    opts.on( '-t', '--end_date END_DATE', _('end date for content export; format: "2011-03-30 00:00:00"') ) do |value|
+    opts.on( '-n', '--end_date END_DATE', _('end date for content export; format: "2011-03-30 00:00:00"') ) do |value|
       options[:end_date] = value
     end
     

--- a/utils/lib/disconnected_pulp.rb
+++ b/utils/lib/disconnected_pulp.rb
@@ -329,8 +329,7 @@ private
       repo_path = d['config']['relative_url'] if d['id'] == 'yum_distributor'
     end
     # if not found default to / 
-    repo_path = '/' unless not repo_path.nil?
-    repo_path
+    repo_path ||= '/'
   end
   
 end


### PR DESCRIPTION
This is the first commit to support puppet syncing for disconnected.

The export is non-functional until we wait for the new Puppet Master
Distributor from the Pulp 2.3 release.
