### PR TITLE
fix katello-utils rpm dependencies

### DIFF
--- a/utils/katello-utils.spec
+++ b/utils/katello-utils.spec
@@ -30,10 +30,8 @@ Source0:        https://fedorahosted.org/releases/k/a/katello/%{name}-%{version}
 
 Requires:       coreutils
 Requires:       unzip
-Requires:       katello-common
-Requires:       katello
-Requires:       katello-glue-pulp
 Requires:       %{?scl_prefix}rubygems
+Requires:       %{?scl_prefix}rubygem(katello)
 Requires:       %{?scl_prefix}rubygem(json)
 Requires:       %{?scl_prefix}rubygem(activesupport)
 Requires:       %{?scl_prefix}rubygem(oauth)


### PR DESCRIPTION
Dependent on other fixes for katello-utils to work with the new katello rubygem and https://github.com/Katello/katello/pull/3648 to fix the gem provides for SCL builds.
