### PR TITLE
Make sure gpgcheck is properly set in repo file.

### DIFF
--- a/scripts/iso/README
+++ b/scripts/iso/README
@@ -8,5 +8,5 @@ temporary yum repo file on your machine, and will install the packages
 for you. This script will also handle updates to an already installed
 machine.
 
-Step 2 is to run katello_configure as documented in the installation
+Step 2 is to run katello-installer as documented in the installation
 guide. This will configure the machine so that it is ready to run.

--- a/scripts/iso/install_packages
+++ b/scripts/iso/install_packages
@@ -86,6 +86,10 @@ shutil.copytree(ISO_REPODATA_DIR, DEST_REPODATA_DIR)
 
 
 # Create a yum repository pointing to the current directory
+# making sure to disable gpgcheck if packages are not signed
+
+GPG_CHECK = 0 if opts.nogpgsigs else 1
+
 print INDENT + "Creating a Repository File"
 repo_file = open(REPO_FILE, 'w')
 repo_file.write("""#
@@ -95,7 +99,7 @@ repo_file.write("""#
 name=katello-local
 baseurl=file://%s
 enabled=1
-gpgcheck=1""" % (DEST_DIR))
+gpgcheck=%s""" % (DEST_DIR, GPG_CHECK))
 repo_file.close()
 
 # Determine if we need to do install or update


### PR DESCRIPTION
Fixes Bugzilla #1098241.

Since the katello-installer will try to install packages from the
internal repo created by the installer, it is necessary to properly
configure the 'gpgcheck' attribute in the repo file when packages are
not signed.
