### PR TITLE
refs #10777 Use sha256 as default signing algorithm.

### DIFF
--- a/certs-tools/katello_certs_tools/sslToolConfig.py
+++ b/certs-tools/katello_certs_tools/sslToolConfig.py
@@ -52,7 +52,7 @@ LEGACY_CA_CERT_RPM_NAME = 'rhns-ca-cert'
 CA_OPENSSL_CNF_NAME = 'katello-ca-openssl.cnf'
 SERVER_OPENSSL_CNF_NAME = 'katello-server-openssl.cnf'
 
-MD = 'sha1'
+MD = 'sha256'
 CRYPTO = '-des3'
 
 


### PR DESCRIPTION
sha1 has been deprecated by many browsers and throws warnings when the
certificate expires after 12/31/2016.

sha256 should be good for awhile.