### PR TITLE
Update default tagger to be VersionTagger

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,6 +1,6 @@
 [globalconfig]
 default_builder = tito.builder.Builder
-default_tagger = tito.tagger.ReleaseTagger
+default_tagger = tito.tagger.VersionTagger
 
 [katello-nightly-rhel5]
 disttag = .el5


### PR DESCRIPTION
As part of the branching process, we can update it to ReleaseTagger. This makes it consistent with other repos in the organization (katello-agent, katello-installer).